### PR TITLE
Add global default options file use

### DIFF
--- a/fbless_lib/options.py
+++ b/fbless_lib/options.py
@@ -21,6 +21,7 @@ except ImportError:
 
 CONFIG_FILES = [
     os.path.join(xdg_config_home, "fbless", "fblessrc"),
+    '/etc/fblessrc',
     os.path.expanduser("~/.fblessrc"),
 ]
 


### PR DESCRIPTION
Добавляет глобальный файл опций /etc/fblessrc.
Я проверил, строка должна быть выше конфига в домашнем каталоге, тогда испольуется последний найденный конфиг.